### PR TITLE
Add credentials column to coxcluster output

### DIFF
--- a/api/v1beta1/coxcluster_types.go
+++ b/api/v1beta1/coxcluster_types.go
@@ -63,6 +63,7 @@ type CoxClusterStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this CoxCluster belongs"
+// +kubebuilder:printcolumn:name="Credentials",type="string",JSONPath=".spec.credentials.name",description="Cluster Credentials"
 // +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".spec.controlPlaneEndpoint",description="API Endpoint"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Cluster infrastructure is ready for Cox instances"
 

--- a/controllers/coxmachine_controller.go
+++ b/controllers/coxmachine_controller.go
@@ -263,7 +263,7 @@ func (r *CoxMachineReconciler) reconcileNormal(ctx context.Context, machineScope
 				errResp := &coxedge.HTTPError{}
 				if errors.As(err, &errResp) {
 					jsn, _ := json.Marshal(errResp)
-					r.Recorder.Eventf(machineScope.CoxMachine, corev1.EventTypeNormal, "CreatingWorkloadFailed", "Faield to create machine '%s`:`%s`", machineScope.Machine.Name, machineScope.Machine.UID, string(jsn))
+					r.Recorder.Eventf(machineScope.CoxMachine, corev1.EventTypeNormal, "CreatingWorkloadFailed", "Failed to create machine '%s`:`%s`", machineScope.Machine.Name, machineScope.Machine.UID, string(jsn))
 					return ctrl.Result{}, fmt.Errorf("error occurred while creating workload: %v - response: %v", err, string(jsn))
 				}
 				r.Recorder.Eventf(machineScope.CoxMachine, corev1.EventTypeNormal, "CreatingWorkloadFailed", "Failed to create workflow for machine '%s`:`%s`", machineScope.Machine.Name, machineScope.Machine.UID, err.Error())


### PR DESCRIPTION
Adds a new "credentials" column to the output of `kubectl get coxcluster`